### PR TITLE
[ENHANCEMENT] URL validation to automatically prepend 'https://' to links

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,6 +86,12 @@ def shortenAPI():
         print('Long URL Received: ' + str(longUrl))
         print('Keyword Received: '+str(keyword))
 
+        # Check if the URL contains a protocol, if not, prepend 'https://'
+        if not longUrl.startswith(('http://', 'https://')):
+            longUrl = 'https://' + longUrl
+            print('Updated Long URL with https://: ' + str(longUrl))
+
+        # If the keyword is not provided, generate a random one
         if keyword == '':
             keyword = generate_random_string()
             print('New keyword generated:' + str(keyword))

--- a/templates/index.html
+++ b/templates/index.html
@@ -185,7 +185,7 @@
             <form id="shortenForm">
                 <div class="mb-3">
                     <label for="longUrl" class="form-label">Enter Long URL</label>
-                    <input type="url" class="form-control" id="longUrl" placeholder="https://example.com" required>
+                    <input type="text" class="form-control" id="longUrl" placeholder="https://example.com" required>
                 </div>
                 <div class="mb-3">
                     <label for="keyword" class="form-label">Custom Keyword (optional)</label>


### PR DESCRIPTION
This PR enhances the user experience by automatically appending the protocol https:// to URLs if the user does not specify a protocol (e.g., `http://` or `https://`). It improves the functionality for users who might enter URLs like `www.example.com` without the protocol, ensuring that all URLs sent to the backend are valid and functional.

closes #24 

<img width="532" alt="Screenshot 2024-10-12 at 1 55 46 AM" src="https://github.com/user-attachments/assets/f5f8226d-d423-4d58-b4ff-94759ca869e1">

<img width="430" alt="Screenshot 2024-10-12 at 1 55 05 AM" src="https://github.com/user-attachments/assets/8915a3f8-6e2d-4a9e-811b-53215d22461a">
